### PR TITLE
Loosen required Ruby version range in gemspec

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -72,6 +72,7 @@ rspec_task:
       - image: ruby:3.1
       - image: ruby:3.2
       - image: ruby:3.3
+      - image: ruby:4.0
 
   <<: *bundle_cache
 

--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -68,8 +68,6 @@ rubocop_task:
 rspec_task:
   container:
     matrix:
-      - image: ruby:3.0
-      - image: ruby:3.1
       - image: ruby:3.2
       - image: ruby:3.3
       - image: ruby:4.0

--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -70,6 +70,7 @@ rspec_task:
     matrix:
       - image: ruby:3.2
       - image: ruby:3.3
+      - image: ruby:3.4
       - image: ruby:4.0
 
   <<: *bundle_cache

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-packaging
   - rubocop-performance
   - rubocop-rspec
@@ -37,6 +37,6 @@ Style/Documentation:
   Exclude:
     - 'spec/**/*'
 
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Exclude:
     - 'lib/faraday/middleware/encode_xml.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ inherit_mode:
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
   SuggestExtensions: false
   NewCops: enable
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 group :development do
   gem 'pry-byebug', '~> 3.12'
 
-  gem 'gem_toys', '~> 1.0.2'
+  gem 'gem_toys'
   gem 'toys', '~> 0.19.1'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 group :development do
   gem 'pry-byebug', '~> 3.12'
 
-  gem 'gem_toys', '~> 1.0.2'
+  gem 'gem_toys', '~> 1.0'
   gem 'toys', '~> 0.19.1'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,25 +5,25 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'pry-byebug'
+  gem 'pry-byebug', '~> 3.12'
 
-  gem 'gem_toys'
-  gem 'toys'
+  gem 'gem_toys', '~> 1.0.2'
+  gem 'toys', '~> 0.19.1'
 end
 
 group :audit do
-  gem 'bundler-audit'
+  gem 'bundler-audit', '~> 0.9.3'
 end
 
 group :test do
-  gem 'rspec'
-  gem 'simplecov'
-  gem 'simplecov-cobertura'
+  gem 'rspec', '~> 3.0'
+  gem 'simplecov', '~> 0.22'
+  gem 'simplecov-cobertura', '~> 3.1'
 end
 
 group :lint do
-  gem 'rubocop'
-  gem 'rubocop-packaging'
-  gem 'rubocop-performance'
-  gem 'rubocop-rspec'
+  gem 'rubocop', '~> 1.84.1'
+  gem 'rubocop-packaging', '~> 0.6.0'
+  gem 'rubocop-performance', '~> 1.26.1'
+  gem 'rubocop-rspec', '~> 3.9.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 group :development do
   gem 'pry-byebug', '~> 3.12'
 
-  gem 'gem_toys'
+  gem 'gem_toys', '~> 1.0.2'
   gem 'toys', '~> 0.19.1'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,26 +5,25 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'pry-byebug', '~> 3.9'
+  gem 'pry-byebug'
 
-  gem 'gem_toys', '~> 0.14.0'
-  gem 'toys', '~> 0.15.3'
+  gem 'gem_toys'
+  gem 'toys'
 end
 
 group :audit do
-  gem 'bundler', '~> 2.0'
-  gem 'bundler-audit', '~> 0.9.0'
+  gem 'bundler-audit'
 end
 
 group :test do
-  gem 'rspec', '~> 3.0'
-  gem 'simplecov', '~> 0.22.0'
-  gem 'simplecov-cobertura', '~> 2.1'
+  gem 'rspec'
+  gem 'simplecov'
+  gem 'simplecov-cobertura'
 end
 
 group :lint do
-  gem 'rubocop', '~> 1.61.0'
-  gem 'rubocop-packaging', '~> 0.5.2'
-  gem 'rubocop-performance', '~> 1.20.2'
-  gem 'rubocop-rspec', '~> 2.27.0'
+  gem 'rubocop'
+  gem 'rubocop-packaging'
+  gem 'rubocop-performance'
+  gem 'rubocop-rspec'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ end
 
 group :test do
   gem 'rspec', '~> 3.0'
-  gem 'simplecov', '~> 0.22'
+  gem 'simplecov', '~> 0.22.0'
   gem 'simplecov-cobertura', '~> 3.1'
 end
 

--- a/faraday-encode_xml.gemspec
+++ b/faraday-encode_xml.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*', 'README.md', 'LICENSE.md', 'CHANGELOG.md']
 
-  spec.required_ruby_version = '>= 3.0', '< 5'
+  spec.required_ruby_version = '>= 3.2', '< 5'
 
   spec.add_dependency 'faraday', '~> 2.14.0'
   spec.add_dependency 'gyoku', '~> 1.3'

--- a/faraday-encode_xml.gemspec
+++ b/faraday-encode_xml.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.0', '< 5'
 
-  spec.add_runtime_dependency 'faraday', '~> 2.9.0'
-  spec.add_runtime_dependency 'gyoku', '~> 1.3'
+  spec.add_dependency 'faraday', '~> 2.14.0'
+  spec.add_dependency 'gyoku', '~> 1.3'
 end

--- a/faraday-encode_xml.gemspec
+++ b/faraday-encode_xml.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*', 'README.md', 'LICENSE.md', 'CHANGELOG.md']
 
-  spec.required_ruby_version = '>= 3.0', '< 4'
+  spec.required_ruby_version = '>= 3.0', '< 5'
 
   spec.add_runtime_dependency 'faraday', '~> 2.9.0'
   spec.add_runtime_dependency 'gyoku', '~> 1.3'


### PR DESCRIPTION
Hi,

Thanks for this gem.

With Ruby 4.0.0 released, i've loosened the Ruby version to < 5.
